### PR TITLE
Insert questions without querying for them first

### DIFF
--- a/Sources/App/Services/StackOverflowService.swift
+++ b/Sources/App/Services/StackOverflowService.swift
@@ -8,7 +8,6 @@ private typealias Questions = [StackOverflowQuestion]
 struct StackOverflowService: Service {
     let client: Client
     let stackOverflowUrlService: StackOverflowUrlService
-    let decoder: DataDecoder
     let connectionPool: DatabaseConnectionPool<ConfiguredDatabase<PostgreSQLDatabase>>
 
     func getNewStackOverflowQuestions(tag: String) -> Future<[StackOverflowQuestion]> {
@@ -19,70 +18,48 @@ struct StackOverflowService: Service {
 
     private func getQuestions(tag: String, on connection: PostgreSQLConnection) -> EventLoopFuture<Questions> {
         return self.getNewQuestionsFromStackOverflow(tag: tag)
-            .flatMap { questionsFromClient in
-                let foundQuestionIds = questionsFromClient.map { $0.questionId }
-                return self.matchingQuestions(foundQuestionIds, connection: connection)
-                    .flatMap({ questionsFromDatabase in
-                        return self.filterForNewQuestionsAndPersist(
-                            questionsFromDatabase: questionsFromDatabase,
-                            questionsFromClient: questionsFromClient,
-                            connection: connection
-                        )
-                    })
+            .flatMap { questions in
+                let newQuestions = questions.map { question -> Future<StackOverflowQuestion?> in
+                    question.save(on: connection)
+                        .map { .some($0) }
+                        .catchMap { error in
+                            // Silence unique index violation errors
+                            guard let pgError = error as? PostgreSQLError, pgError.identifier == "server.error._bt_check_unique" else {
+                                throw error
+                            }
 
-        }
+                            return nil
+                        }
+                }
+
+                return EventLoopFuture<Questions>.reduce(into: [], newQuestions, eventLoop: connection.eventLoop, { (acc, question) in
+                    guard let question = question else {
+                        return
+                    }
+
+                    acc.append(question)
+                })
+            }
     }
 
     private func getNewQuestionsFromStackOverflow(tag: String) -> EventLoopFuture<Questions> {
         let url = stackOverflowUrlService.requestForQuestions(for: tag)
         return client
             .get(url)
-            .map(to: [StackOverflowQuestion].self, self.decodeResponseData)
-    }
-
-    private func decodeResponseData(_ response: Response) throws -> Questions {
-        let data = response.http.body.data ?? Data()
-        return try self.decoder.decode(StackOverflowQuestionContainer.self,
-                                       from: data).items
-    }
-
-    private func matchingQuestions(
-        _ foundQuestionIds: [Int],
-        connection: PostgreSQLConnection
-    ) -> EventLoopFuture<Questions> {
-        return StackOverflowQuestion
-            .query(on: connection)
-            .filter(\.questionId ~~ foundQuestionIds)
-            .all()
-    }
-
-    private func filterForNewQuestionsAndPersist(
-        questionsFromDatabase: Questions,
-        questionsFromClient: Questions,
-        connection: PostgreSQLConnection
-    ) -> EventLoopFuture<Questions> {
-        let foundQuestionIds = questionsFromClient.map { $0.questionId }
-        let dbQuestionIds = questionsFromDatabase.map { $0.questionId }
-        let unsavedQuestions = Set(foundQuestionIds).subtracting(Set(dbQuestionIds))
-        return questionsFromClient
-            .filter { question in unsavedQuestions.contains(question.questionId) }
-            .map { question -> Future<StackOverflowQuestion>  in
-                return question.save(on: connection)
-        }.flatten(on: connection)
+            .flatMap { try $0.content.decode(ListWrapper<StackOverflowQuestion>.self) }
+            .map { $0.items }
     }
 }
 
 extension StackOverflowService: ServiceType {
     static func makeService(for worker: Container) throws -> StackOverflowService {
-        let jsonDecoder = try worker.make(ContentCoders.self).requireDataDecoder(for: .json)
         let connectionPool = try worker.connectionPool(to: .psql)
         return try StackOverflowService(client: worker.make(),
                                         stackOverflowUrlService: worker.make(),
-                                        decoder: jsonDecoder,
                                         connectionPool: connectionPool)
     }
 }
 
-struct StackOverflowQuestionContainer: Codable {
-    let items: [StackOverflowQuestion]
+private struct ListWrapper<T: Decodable>: Decodable {
+    let items: [T]
 }


### PR DESCRIPTION
This PR simplifies the class that manages the database, and should improve performance at the same time.

Instead of pulling in all the questions by ID and discarding all the data that was transferred, this version attempts to insert the questions as they come, and silences the unique index violations.